### PR TITLE
Run create_sysop only on first startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,7 +55,9 @@ sed -i "/\$Internet::contest_host/s/'//g" ${SPIDER_INSTALL_DIR}/local/DXVars.pm
 
 
 cd ${SPIDER_INSTALL_DIR}/perl && \
-./create_sysop.pl && \
+if [ ! -s ${SPIDER_INSTALL_DIR}/local_data/users.v3j ]; then
+    ./create_sysop.pl
+fi && \
 ./cluster.pl &
 
 sleep 3


### PR DESCRIPTION
Currently create_sysop.pl is executed on every container startup.

This recreates the sysop user and overwrites local changes such as
password updates made through the DXSpider console.

As a result, any modification to the sysop account is lost whenever
the container is restarted.

This change runs create_sysop.pl only when the user database
(local_data/users.v3j) does not exist or is empty, preserving the
initial initialization behaviour while keeping user data persistent
across restarts.
Behaviour before:
- create_sysop.pl runs on every startup
- sysop user is recreated
- password changes are lost after restart

Behaviour after:
- create_sysop.pl runs only if the user database does not exist
- existing users and sysop configuration persist across restarts